### PR TITLE
QC Script for Backtesting a Date Range

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,2 +1,4 @@
 QC_USER_ID=#####
 QC_ACCESS_TOKEN=################################
+
+QC_BACKTEST_DATERANGE_PID=#######

--- a/qc_backtest_daterange.py
+++ b/qc_backtest_daterange.py
@@ -38,21 +38,6 @@ class QCHelper(AlgorithmLabToolkit):
                                          fileName=params_filename,
                                          newFileContents=config_file_txt)
 
-#
-# def setup_logging():
-#     import logging.handlers
-#     qc = QCHelper()
-#     log_dir = os.path.join(qc.dir_script, 'log')
-#     if not os.path.isdir(log_dir):
-#         os.mkdir(os.path.join(qc.dir_script, 'log'))
-#     log_filename = 'log/algolab.log'
-#     log = logging.getLogger('algolab_logger')
-#     log.setLevel(logging.DEBUG)
-#     # Add handler to create new log file every 10MB
-#     file_handler = logging.handlers.RotatingFileHandler(
-#         log_filename, maxBytes=10*1024*1024, backupCount=5)
-#     log.addHandler(file_handler)
-
 
 def update_project_params(start_date,
                           end_date):
@@ -60,7 +45,7 @@ def update_project_params(start_date,
     #                   'END_DATE = \'{}\'\n'.format(start_date, end_date)
     daterange = {'start_date': start_date, 'end_date': end_date}
     params_file_contents = 'daterange = {}\n'.format(daterange)
-    qc = QCHelper()
+
     cur_proj_dir = qc.get_project_directory()
     params_filepath = os.path.join(cur_proj_dir, params_filename)
     with open(params_filepath, 'w') as f:
@@ -69,7 +54,6 @@ def update_project_params(start_date,
 
 
 def compile_project():
-    qc = QCHelper()
     print('Compiling project...')
     compile_results = qc.create_compile(qc.pid)
     compile_id = compile_results['compileId']
@@ -93,7 +77,6 @@ def compile_project():
 
 
 def backtest_compiled_project(compile_id):
-    qc = QCHelper()
     print('Triggering project backtest...')
     backtest_name = '{}_{}'.format(
         qc.pid, str(dt.datetime.now())[:19].replace(' ', '_').replace(':', ''))
@@ -137,6 +120,7 @@ if __name__ == '__main__':
     parser.add_argument('-e', '--end_date', metavar=('<end-date>',),
                         default=None, help="Last date to run algo on")
     args = parser.parse_args()
+    qc = QCHelper()
     update_project_params(args.start_date,
                           args.end_date)
     compilation_id = compile_project()

--- a/qc_backtest_daterange.py
+++ b/qc_backtest_daterange.py
@@ -11,13 +11,13 @@ from dotenv import load_dotenv
 from code.qc.algolab import models
 from code.qc.api.wrapper import QCApi
 
-dir_script = os.path.dirname(os.path.realpath(__file__))
-dotenv_path = os.path.join(os.getcwd(), '.env')
-load_dotenv(dotenv_path)
+# dir_path = os.path.dirname(os.path.realpath(__file__))
+# dotenv_path = os.path.join(os.getcwd(), '.env')
+# load_dotenv(dotenv_path)
 
-uid = os.environ['QC_USER_ID'],
-token = os.environ['QC_ACCESS_TOKEN']
-pid = os.environ['QC_BACKTEST_DATERANGE_PID']
+# uid = os.environ['QC_USER_ID'],
+# token = os.environ['QC_ACCESS_TOKEN']
+# pid = os.environ['QC_BACKTEST_DATERANGE_PID']
 
 
 class QCHelper(QCApi):
@@ -25,11 +25,15 @@ class QCHelper(QCApi):
 
     def __init__(self):
         self.dir_qc_proj = os.path.dirname(os.path.realpath(models.__file__))
-        super(QCHelper, self).__init__(userId=uid, token=token)
+        self.dir_script = os.path.dirname(os.path.realpath(__file__))
+        self.dotenv_path = os.path.join(os.getcwd(), '.env')
+        load_dotenv(self.dotenv_path)
+        self.pid = os.environ['QC_BACKTEST_DATERANGE_PID']
+        super(QCHelper, self).__init__(userId=os.environ['QC_USER_ID'], token=os.environ['QC_ACCESS_TOKEN'])
 
     def get_project_directory(self):
 
-        project_response = self.read_project(pid)
+        project_response = self.read_project(self.pid)
         project_details = project_response['projects'][0]
         filename = os.path.join(self.dir_qc_proj, 'project_files/{}_{}'.format(
             project_details['projectId'],
@@ -37,17 +41,18 @@ class QCHelper(QCApi):
         return filename
 
     def update_config_params(self, config_file_txt):
-        self.update_project_file_content(projectId=pid,
+        self.update_project_file_content(projectId=self.pid,
                                          fileName='conf.py',
                                          newFileContents=config_file_txt)
 
 
 def setup_logging():
-    log_dir = os.path.join(dir_script, 'log')
+    qc = QCHelper()
+    log_dir = os.path.join(qc.dir_script, 'log')
     if not os.path.isdir(log_dir):
-        os.mkdir(os.path.join(dir_script, 'log'))
-    log_filename = 'log/qc_backtest_daterange.log'
-    log = logging.getLogger('qc_backtest_daterange_logger')
+        os.mkdir(os.path.join(qc.dir_script, 'log'))
+    log_filename = 'log/algolab.log'
+    log = logging.getLogger('algolab_logger')
     log.setLevel(logging.DEBUG)
 
     # Add handler to create new log file every 10MB
@@ -73,11 +78,11 @@ def update_project_params(start_date,
 def compile_project():
     qc = QCHelper()
     print('Compiling project...')
-    compile_results = qc.create_compile(pid)
+    compile_results = qc.create_compile(qc.pid)
     compile_id = compile_results['compileId']
     print('Checking compilation results')
     while True:
-        compile_read_status_results = qc.read_compile(pid, compile_id)
+        compile_read_status_results = qc.read_compile(qc.pid, compile_id)
 
         if compile_read_status_results['state'] == 'InQueue':
             time.sleep(15)  # seconds
@@ -98,20 +103,20 @@ def backtest_compiled_project(compile_id):
     qc = QCHelper()
     print('Triggering project backtest...')
     backtest_name = '{}_{}'.format(
-        pid, str(dt.datetime.now())[:19].replace(' ', '_').replace(':', ''))
-    backtest_results = qc.create_backtest(pid, compile_id, backtest_name)
+        qc.pid, str(dt.datetime.now())[:19].replace(' ', '_').replace(':', ''))
+    backtest_results = qc.create_backtest(qc.pid, compile_id, backtest_name)
     backtest_id = backtest_results['backtestId']
-    backtest_read_results = qc.read_backtest(pid, backtest_id)
+    backtest_read_results = qc.read_backtest(qc.pid, backtest_id)
     while backtest_read_results['progress'] < 1:
         print('Waiting for backtest to complete...')
         time.sleep(15)
-        backtest_read_results = qc.read_backtest(pid, backtest_id)
+        backtest_read_results = qc.read_backtest(qc.pid, backtest_id)
     if backtest_read_results['completed'] is True:
         print(backtest_read_results['result'])
         print('Successful backtest! Downloading log file...')
 
         log_url = 'https://www.quantconnect.com/backtests/{}/{}/{}-log.txt'.format(
-            uid, pid, backtest_id)
+            os.environ['QC_USER_ID'], qc.pid, backtest_id)
 
         filename = '{}_{}-log.txt'.format(backtest_name, backtest_id)
         backtest_log_dir = os.path.join(qc.get_project_directory(), 'backtest_logs')

--- a/qc_backtest_daterange.py
+++ b/qc_backtest_daterange.py
@@ -131,7 +131,6 @@ if __name__ == '__main__':
     setup_logging()
 
     """ Parse arguments from CLI """
-    # python algolab.py --push_project 1231453647441324, live-algo-name, <code>
     parser = argparse.ArgumentParser(description='Backtest date param passing demo')
     parser.add_argument('-s', '--start_date', nargs=1, metavar=('<start-date>',), default=None, help="First date to run algo on")
     parser.add_argument('-e', '--end_date', nargs=1, metavar=('<end-date>',), default=None, help="Last date to run algo on")

--- a/qc_backtest_daterange.py
+++ b/qc_backtest_daterange.py
@@ -1,23 +1,18 @@
 # -*- coding: utf-8 -*-
 import argparse
+import datetime as dt
 import logging.handlers
 import os
 import time
-import datetime as dt
 import urllib.request
 
 from dotenv import load_dotenv
 
 from code.qc.algolab import models
 from code.qc.api.wrapper import QCApi
+# from code.qc.algolab.models import AlgorithmLabToolkit
 
-# dir_path = os.path.dirname(os.path.realpath(__file__))
-# dotenv_path = os.path.join(os.getcwd(), '.env')
-# load_dotenv(dotenv_path)
-
-# uid = os.environ['QC_USER_ID'],
-# token = os.environ['QC_ACCESS_TOKEN']
-# pid = os.environ['QC_BACKTEST_DATERANGE_PID']
+params_filename = 'params.py'
 
 
 class QCHelper(QCApi):
@@ -29,10 +24,11 @@ class QCHelper(QCApi):
         self.dotenv_path = os.path.join(os.getcwd(), '.env')
         load_dotenv(self.dotenv_path)
         self.pid = os.environ['QC_BACKTEST_DATERANGE_PID']
-        super(QCHelper, self).__init__(userId=os.environ['QC_USER_ID'], token=os.environ['QC_ACCESS_TOKEN'])
+        self.uid = os.environ['QC_USER_ID']
+        super(QCHelper, self).__init__(userId=os.environ['QC_USER_ID'],
+                                       token=os.environ['QC_ACCESS_TOKEN'])
 
     def get_project_directory(self):
-
         project_response = self.read_project(self.pid)
         project_details = project_response['projects'][0]
         filename = os.path.join(self.dir_qc_proj, 'project_files/{}_{}'.format(
@@ -42,7 +38,7 @@ class QCHelper(QCApi):
 
     def update_config_params(self, config_file_txt):
         self.update_project_file_content(projectId=self.pid,
-                                         fileName='conf.py',
+                                         fileName=params_filename,
                                          newFileContents=config_file_txt)
 
 
@@ -54,7 +50,6 @@ def setup_logging():
     log_filename = 'log/algolab.log'
     log = logging.getLogger('algolab_logger')
     log.setLevel(logging.DEBUG)
-
     # Add handler to create new log file every 10MB
     file_handler = logging.handlers.RotatingFileHandler(
         log_filename, maxBytes=10*1024*1024, backupCount=5)
@@ -63,16 +58,16 @@ def setup_logging():
 
 def update_project_params(start_date,
                           end_date):
-    config_file_txt = 'START_DATE = \'{}\'\n' \
-                      'END_DATE = \'{}\'\n'.format(start_date[0], end_date[0])
+    # config_file_txt = 'START_DATE = \'{}\'\n' \
+    #                   'END_DATE = \'{}\'\n'.format(start_date, end_date)
+    daterange = {'start_date': start_date, 'end_date': end_date}
+    params_file_contents = 'daterange = {}\n'.format(daterange)
     qc = QCHelper()
     cur_proj_dir = qc.get_project_directory()
-    config_filepath = os.path.join(cur_proj_dir, 'conf.py')
-    # save file locally
-    with open(config_filepath, 'w') as f:
-        f.write(config_file_txt)
-    # update remotely
-    qc.update_config_params(config_file_txt)
+    params_filepath = os.path.join(cur_proj_dir, params_filename)
+    with open(params_filepath, 'w') as f:
+        f.write(params_file_contents)                # save file locally
+    qc.update_config_params(params_file_contents)    # update remotely
 
 
 def compile_project():
@@ -106,39 +101,46 @@ def backtest_compiled_project(compile_id):
         qc.pid, str(dt.datetime.now())[:19].replace(' ', '_').replace(':', ''))
     backtest_results = qc.create_backtest(qc.pid, compile_id, backtest_name)
     backtest_id = backtest_results['backtestId']
-    backtest_read_results = qc.read_backtest(qc.pid, backtest_id)
-    while backtest_read_results['progress'] < 1:
+    while True:
+        backtest_read_results = qc.read_backtest(qc.pid, backtest_id)
+        if backtest_read_results['completed'] is True and backtest_read_results['progress'] == 1:
+            print(backtest_read_results['result'])
+            print('Successful backtest! Downloading log file...')
+            log_url = 'https://www.quantconnect.com/backtests/{}/{}/{}-log.txt'.format(
+                qc.uid, qc.pid, backtest_id)
+            filename = '{}_{}-log.txt'.format(backtest_name, backtest_id)
+            backtest_log_dir = os.path.join(qc.get_project_directory(), 'backtest_logs')
+            if not os.path.exists(backtest_log_dir):
+                os.makedirs(backtest_log_dir)
+            file_path = os.path.join(backtest_log_dir, filename)
+            urllib.request.urlretrieve(log_url, file_path)
+            print('Backtest log file saved to: {}'.format(file_path))
+            return file_path
         print('Waiting for backtest to complete...')
         time.sleep(15)
-        backtest_read_results = qc.read_backtest(qc.pid, backtest_id)
-    if backtest_read_results['completed'] is True:
-        print(backtest_read_results['result'])
-        print('Successful backtest! Downloading log file...')
 
-        log_url = 'https://www.quantconnect.com/backtests/{}/{}/{}-log.txt'.format(
-            os.environ['QC_USER_ID'], qc.pid, backtest_id)
 
-        filename = '{}_{}-log.txt'.format(backtest_name, backtest_id)
-        backtest_log_dir = os.path.join(qc.get_project_directory(), 'backtest_logs')
-        if not os.path.exists(backtest_log_dir):
-            os.makedirs(backtest_log_dir)
-        file_path = os.path.join(backtest_log_dir, filename)
-        urllib.request.urlretrieve(log_url, file_path)
-        return file_path
+def read_file_to_log(file_path):
+    with open(file_path, 'r') as f:
+        lines = f.read().splitlines()
+        log_txt = '\n'
+        for line in lines:
+            log_txt += '{}\n'.format(line)
+        print(log_txt)
 
 
 if __name__ == '__main__':
     setup_logging()
-
     """ Parse arguments from CLI """
     parser = argparse.ArgumentParser(description='Backtest date param passing demo')
-    parser.add_argument('-s', '--start_date', nargs=1, metavar=('<start-date>',), default=None, help="First date to run algo on")
-    parser.add_argument('-e', '--end_date', nargs=1, metavar=('<end-date>',), default=None, help="Last date to run algo on")
-
+    parser.add_argument('-s', '--start_date', metavar=('<start-date>',),
+                        default=None, help="First date to run algo on")
+    parser.add_argument('-e', '--end_date', metavar=('<end-date>',),
+                        default=None, help="Last date to run algo on")
     args = parser.parse_args()
-
     update_project_params(args.start_date,
                           args.end_date)
-    compile_id = compile_project()
-    backtest_compiled_project(compile_id)
+    compilation_id = compile_project()
+    backtest_log_filepath = backtest_compiled_project(compilation_id)
+    read_file_to_log(backtest_log_filepath)
     print('Done.')

--- a/qc_backtest_daterange.py
+++ b/qc_backtest_daterange.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+import argparse
+import logging.handlers
+import os
+import time
+import urllib.request
+
+from dotenv import load_dotenv
+
+from code.qc.algolab import models
+from code.qc.api.wrapper import QCApi
+
+# dir_path = os.path.dirname(os.path.realpath(__file__))
+# dotenv_path = os.path.join(os.getcwd(), '.env')
+# load_dotenv(dotenv_path)
+
+# uid = os.environ['QC_USER_ID'],
+# token = os.environ['QC_ACCESS_TOKEN']
+# pid = os.environ['QC_BACKTEST_DATERANGE_PID']
+
+
+class QCHelper(QCApi):
+    """ Toolkit for the QuantConnect CommandLine AlgorithmLab API Interactor Tool """
+
+    def __init__(self):
+        self.dir_qc_proj = os.path.dirname(os.path.realpath(models.__file__))
+        self.dir_script = os.path.dirname(os.path.realpath(__file__))
+        self.dotenv_path = os.path.join(os.getcwd(), '.env')
+        load_dotenv(self.dotenv_path)
+        self.pid = os.environ['QC_BACKTEST_DATERANGE_PID']
+        super(QCHelper, self).__init__(userId=os.environ['QC_USER_ID'], token=os.environ['QC_ACCESS_TOKEN'])
+
+    def get_project_directory(self):
+
+        project_response = self.read_project(self.pid)
+        project_details = project_response['projects'][0]
+        filename = os.path.join(self.dir_qc_proj, 'project_files/{}_{}'.format(
+            project_details['projectId'],
+            project_details['name']))
+        return filename
+
+    def update_config_params(self, config_file_txt):
+        self.update_project_file_content(projectId=self.pid,
+                                         fileName='conf.py',
+                                         newFileContents=config_file_txt)
+
+
+def setup_logging():
+    qc = QCHelper()
+    log_dir = os.path.join(qc.dir_script, 'log')
+    if not os.path.isdir(log_dir):
+        os.mkdir(os.path.join(qc.dir_script, 'log'))
+    log_filename = 'log/algolab.log'
+    log = logging.getLogger('algolab_logger')
+    log.setLevel(logging.DEBUG)
+
+    # Add handler to create new log file every 10MB
+    file_handler = logging.handlers.RotatingFileHandler(
+        log_filename, maxBytes=10*1024*1024, backupCount=5)
+    log.addHandler(file_handler)
+
+
+def update_project_params(start_date,
+                          end_date):
+    config_file_txt = 'START_DATE = \'{}\'\n' \
+                      'END_DATE = \'{}\'\n'.format(start_date[0], end_date[0])
+    qc = QCHelper()
+    cur_proj_dir = qc.get_project_directory()
+    config_filepath = os.path.join(cur_proj_dir, 'conf.py')
+    # save file locally
+    with open(config_filepath, 'w') as f:
+        f.write(config_file_txt)
+    # update remotely
+    qc.update_config_params(config_file_txt)
+
+
+def compile_project():
+    qc = QCHelper()
+    print('Compiling project...')
+    compile_results = qc.create_compile(qc.pid)
+    compile_id = compile_results['compileId']
+    print('Checking compilation results')
+    while True:
+        compile_read_status_results = qc.read_compile(qc.pid, compile_id)
+
+        if compile_read_status_results['state'] == 'InQueue':
+            time.sleep(15)  # seconds
+            print('Compilation still in queue: waiting.')
+        elif compile_read_status_results['state'] == 'BuildError':
+            print(compile_read_status_results['logs'])
+            exit(0)
+        elif compile_read_status_results['state'] == 'BuildSuccess':
+            print(compile_read_status_results['logs'])
+            return compile_id
+        else:
+            print(compile_read_status_results)
+            print('Error')
+            exit(0)
+
+
+def backtest_compiled_project(compile_id):
+    qc = QCHelper()
+    print('Triggering project backtest...')
+    backtest_results = qc.create_backtest(qc.pid, compile_id, 'backtest_name_02')
+    backtest_id = backtest_results['backtestId']
+    backtest_read_results = qc.read_backtest(qc.pid, backtest_id)
+    print(backtest_read_results)
+    while backtest_read_results['progress'] < 1:
+        print('Waiting for backtest to complete...')
+        time.sleep(15)
+        backtest_read_results = qc.read_backtest(qc.pid, backtest_id)
+    if backtest_read_results['completed'] is True:
+        print(backtest_read_results['result'])
+        print('Successful backtest! Downloading log file')
+
+        log_url = 'https://www.quantconnect.com/backtests/{}/{}/{}-log.txt'.format(
+            os.environ['QC_USER_ID'], qc.pid, backtest_id)
+
+        filename = '{}-log.txt'.format(backtest_id)
+        log_dir = os.path.join(qc.get_project_directory(), 'backtest_logs')
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+        file_path = os.path.join(log_dir, filename)
+        urllib.request.urlretrieve(log_url, file_path)
+        return file_path
+
+
+if __name__ == '__main__':
+    setup_logging()
+
+    """ Parse arguments from CLI """
+    # python algolab.py --push_project 1231453647441324, live-algo-name, <code>
+    parser = argparse.ArgumentParser(description='Backtest date param passing demo')
+    parser.add_argument('-s', '--start_date', nargs=1, metavar=('<start-date>',), default=None, help="First date to run algo on")
+    parser.add_argument('-e', '--end_date', nargs=1, metavar=('<end-date>',), default=None, help="Last date to run algo on")
+
+    args = parser.parse_args()
+
+    update_project_params(args.start_date,
+                          args.end_date)
+    compile_id = compile_project()
+    backtest_compiled_project(compile_id)
+    print('Done.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ sphinx==1.8.1
 python-dotenv==0.9.1
 requests==2.19.1
 quantconnect==0.1
-
+wget==3.2


### PR DESCRIPTION
This script is intended to demonstrate a handful of things we can do with programatic API access to QC. Specifically it performs the following actions:

1. updates the dates in local `params.py` to reflect the user’s input
2. push updates to all existing project files located on QC cloud/website
3. compiles the project (with new dates in `params.py`) using the PID located in `.env`
4. when compilation is finished trigger backtest of newly compiled project
5. when backtest is finished print results and download log file